### PR TITLE
Build shadowed jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 
 // add javadoc/source jar tasks as artifacts
 artifacts {
-    archives sourcesJar, javadocJar
+    archives sourcesJar, javadocJar, shadowJar
 }
 
 githubPages {
@@ -87,7 +87,7 @@ shadowJar {
     exclude 'META-INF/*.DSA'
     exclude 'META-INF/*.RSA'
     mergeServiceFiles()
-    classifier = 'all'
+    classifier = 'shadowed'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,17 @@ githubPages {
     }
 }
 
+shadowJar {
+    relocate 'javax.annotation', 'com.launchdarkly.shaded.javax.annotation'
+    relocate 'javax.inject', 'com.launchdarkly.shaded.javax.inject'
+    relocate 'javax.ws.rs', 'com.launchdarkly.shaded.javax.ws.rs'
+    exclude 'META-INF/*.SF'
+    exclude 'META-INF/*.DSA'
+    exclude 'META-INF/*.RSA'
+    mergeServiceFiles()
+    classifier = 'all'
+}
+
 test {
     testLogging {
         events "passed", "skipped", "failed", "standardOut", "standardError"

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'maven'
 apply plugin: 'org.ajoberstar.github-pages'
 apply plugin: 'signing'
 apply plugin: 'idea'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 repositories {
     mavenCentral()
@@ -47,6 +48,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.ajoberstar:gradle-git:0.12.0'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.2'
     }
 }
 


### PR DESCRIPTION
This new gradle configuration publishes an additional shadowed jar artifact. This jar has key classes from Jersey 2 renamed, which should make it possible to co-exist with Jersey 1.

Customers should be able to specify this jar by using a maven classifier attribute, pointing to 'shadowed'. If this works after further testing, it may be preferable to make this our primary artifact.