### PR TITLE
Simpler configuration for shadow plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'maven'
 apply plugin: 'org.ajoberstar.github-pages'
 apply plugin: 'signing'
 apply plugin: 'idea'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 repositories {
     mavenCentral()
@@ -49,6 +50,7 @@ buildscript {
     }
     dependencies {
         classpath 'org.ajoberstar:gradle-git:0.12.0'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.2'
     }
 }
 
@@ -65,7 +67,7 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 
 // add javadoc/source jar tasks as artifacts
 artifacts {
-    archives sourcesJar, javadocJar
+    archives sourcesJar, javadocJar, shadowJar
 }
 
 githubPages {
@@ -77,6 +79,10 @@ githubPages {
         username = githubUser
         password = githubPassword
     }
+}
+
+shadowJar {
+    classifier = 'all'
 }
 
 test {


### PR DESCRIPTION
This cherry-picks some of Patrick's work to build a shadow jar with a line to save the artifact. I added a bunch of commits in the other branch to try to get Jersey 1 to co-exist with Jersey 2, but that ended up not working.