### PR TITLE
RedisFeatureStore config and functionality additions

### DIFF
--- a/src/main/java/com/launchdarkly/client/RedisFeatureStoreBuilder.java
+++ b/src/main/java/com/launchdarkly/client/RedisFeatureStoreBuilder.java
@@ -1,0 +1,181 @@
+package com.launchdarkly.client;
+
+import org.apache.http.client.utils.URIBuilder;
+import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.Protocol;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This class exposes advanced configuration options for the {@link com.launchdarkly.client.RedisFeatureStore}.
+ *
+ * A <a href="http://en.wikipedia.org/wiki/Builder_pattern">builder</a> that helps construct {@link com.launchdarkly.client.RedisFeatureStore} objects.
+ * {@link RedisFeatureStoreBuilder} calls can be chained, enabling the following pattern:
+ *
+ * <pre>
+ * RedisFeatureStoreBuilder builder = new RedisFeatureStoreBuilder("host", 443, 60)
+ *      .refreshStaleValues(true)
+ *      .asyncRefresh(true)
+ *      .socketTimeout(200)
+ *      .build()
+ * </pre>
+ */
+public class RedisFeatureStoreBuilder {
+    protected boolean refreshStaleValues = false;
+    protected boolean asyncRefresh = false;
+    protected URI uri;
+    protected String prefix;
+    protected int connectTimeout = Protocol.DEFAULT_TIMEOUT;
+    protected int socketTimeout = Protocol.DEFAULT_TIMEOUT;
+    protected long cacheTimeSecs;
+    protected JedisPoolConfig poolConfig;
+
+    /**
+     * The constructor accepts the mandatory fields that must be specified at a minimum to construct a {@link com.launchdarkly.client.RedisFeatureStore}.
+     *
+     * @param uri the uri of the Redis resource to connect to.
+     * @param cacheTimeSecs the cache time in seconds. See {@link RedisFeatureStoreBuilder#cacheTime(long, TimeUnit)} for more information.
+     */
+    public RedisFeatureStoreBuilder(URI uri, long cacheTimeSecs) {
+        this.uri = uri;
+        this.cacheTimeSecs = cacheTimeSecs;
+    }
+
+    /**
+     * The constructor accepts the mandatory fields that must be specified at a minimum to construct a {@link com.launchdarkly.client.RedisFeatureStore}.
+     *
+     * @param scheme the URI scheme to use
+     * @param host the hostname to connect to
+     * @param port the port to connect to
+     * @param cacheTimeSecs the cache time in seconds. See {@link RedisFeatureStoreBuilder#cacheTime(long, TimeUnit)} for more information.
+     * @throws URISyntaxException
+     */
+    public RedisFeatureStoreBuilder(String scheme, String host, int port, long cacheTimeSecs) throws URISyntaxException {
+        this.uri = new URIBuilder().setScheme(scheme).setHost(host).setPort(port).build();
+        this.cacheTimeSecs = cacheTimeSecs;
+    }
+
+    /**
+     * Optionally set the {@link RedisFeatureStore} local cache to refresh stale values instead of evicting them (the default behaviour).
+     *
+     * When enabled; the cache refreshes stale values instead of completely evicting them. This mode returns the previously cached, stale values if
+     * anything goes wrong during the refresh phase (for example a connection timeout). If there was no previously cached value then the store will
+     * return null (resulting in the default value being returned). This is useful if you prefer the most recently cached feature rule set to be returned
+     * for evaluation over the default value when updates go wrong.
+     *
+     * When disabled; results in a behaviour which evicts stale values from the local cache and retrieves the latest value from Redis. If the updated value
+     * can not be returned for whatever reason then a null is returned (resulting in the default value being returned).
+     *
+     * This property has no effect if the cache time is set to 0. See {@link RedisFeatureStoreBuilder#cacheTime(long, TimeUnit)} for details.
+     *
+     * See: <a href="https://github.com/google/guava/wiki/CachesExplained#refresh">CacheBuilder</a> for more specific information on cache semantics.
+     *
+     * @param enabled turns on lazy refresh of cached values.
+     * @return the builder
+     */
+    public RedisFeatureStoreBuilder refreshStaleValues(boolean enabled) {
+        this.refreshStaleValues = enabled;
+        return this;
+    }
+
+    /**
+     * Optionally make cache refresh mode asynchronous. This setting only works if {@link RedisFeatureStoreBuilder#refreshStaleValues(boolean)} has been enabled
+     * and has no effect otherwise.
+     *
+     * Upon hitting a stale value in the local cache; the refresh of the value will be asynchronous which will return the previously cached value in a
+     * non-blocking fashion to threads requesting the stale key. This internally will utilize a {@link java.util.concurrent.Executor} to asynchronously
+     * refresh the stale value upon the first read request for the stale value in the cache.
+     *
+     * If there was no previously cached value then the feature store returns null (resulting in the default value being returned). Any exception
+     * encountered during the asynchronous reload will simply keep the previously cached value instead.
+     *
+     * This setting is ideal to enable when you desire high performance reads and can accept returning stale values for the period of the async refresh. For
+     * example configuring this feature store with a very low cache time and enabling this feature would see great performance benefit by decoupling calls
+     * from network I/O.
+     *
+     * This property has no effect if the cache time is set to 0. See {@link RedisFeatureStoreBuilder#cacheTime(long, TimeUnit)} for details.
+     *
+     * @param enabled turns on asychronous refreshes on.
+     * @return the builder
+     */
+    public RedisFeatureStoreBuilder asyncRefresh(boolean enabled) {
+        this.asyncRefresh = enabled;
+        return this;
+    }
+
+    /**
+     * Optionally configures the namespace prefix for all keys stored in Redis.
+     *
+     * @param prefix
+     * @return the builder
+     */
+    public RedisFeatureStoreBuilder prefix(String prefix) {
+        this.prefix = prefix;
+        return this;
+    }
+
+    /**
+     * A mandatory field which configures the amount of time the store should internally cache the value before being marked invalid.
+     *
+     * The eviction strategy of stale values is determined by the configuration picked. See {@link RedisFeatureStoreBuilder#refreshStaleValues(boolean)} for
+     * more information on stale value updating strategies.
+     *
+     * If this value is set to 0 then it effectively disables local caching altogether.
+     *
+     * @param cacheTime the time value to cache for
+     * @param timeUnit the time unit for the time value. This is used to convert your time value to seconds.
+     * @return the builder
+     */
+    public RedisFeatureStoreBuilder cacheTime(long cacheTime, TimeUnit timeUnit) {
+        this.cacheTimeSecs = timeUnit.toSeconds(cacheTime);
+        return this;
+    }
+
+    /**
+     * Optional override if you wish to specify your own configuration to the underlying Jedis pool.
+     *
+     * @param poolConfig the Jedis pool configuration.
+     * @return the builder
+     */
+    public RedisFeatureStoreBuilder poolConfig(JedisPoolConfig poolConfig) {
+        this.poolConfig = poolConfig;
+        return this;
+    }
+
+    /**
+     * Optional override which sets the connection timeout for the underlying Jedis pool which otherwise defaults to
+     * {@link redis.clients.jedis.Protocol#DEFAULT_TIMEOUT}
+     *
+     * @param connectTimeout the timeout
+     * @param timeUnit the time unit for the timeout
+     * @return the builder
+     */
+    public RedisFeatureStoreBuilder connectTimeout(int connectTimeout, TimeUnit timeUnit) {
+        this.connectTimeout = (int) timeUnit.toMillis(connectTimeout);
+        return this;
+    }
+
+    /**
+     * Optional override which sets the connection timeout for the underlying Jedis pool which otherwise defaults to
+     * {@link redis.clients.jedis.Protocol#DEFAULT_TIMEOUT}
+     *
+     * @param socketTimeout the socket timeout
+     * @param timeUnit the time unit for the timeout
+     * @return the builder
+     */
+    public RedisFeatureStoreBuilder socketTimeout(int socketTimeout, TimeUnit timeUnit) {
+        this.socketTimeout = (int) timeUnit.toMillis(socketTimeout);
+        return this;
+    }
+
+    /**
+     * Build a {@link RedisFeatureStore} based on the currently configured builder object.
+     *
+     * @return the {@link RedisFeatureStore} configured by this builder.
+     */
+    public RedisFeatureStore build() {
+        return new RedisFeatureStore(this);
+    }
+}

--- a/src/test/java/com/launchdarkly/client/RedisFeatureStoreBuilderTest.java
+++ b/src/test/java/com/launchdarkly/client/RedisFeatureStoreBuilderTest.java
@@ -1,0 +1,85 @@
+package com.launchdarkly.client;
+
+import org.junit.Test;
+import redis.clients.jedis.JedisPoolConfig;
+import redis.clients.jedis.Protocol;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class RedisFeatureStoreBuilderTest {
+
+    @Test
+    public void testDefaultValues() throws URISyntaxException {
+        RedisFeatureStoreBuilder conf = new RedisFeatureStoreBuilder("http", "host", 1234, 1);
+        assertEquals(Protocol.DEFAULT_TIMEOUT, conf.connectTimeout);
+        assertEquals(Protocol.DEFAULT_TIMEOUT, conf.socketTimeout);
+        assertEquals(false, conf.refreshStaleValues);
+        assertEquals(false, conf.asyncRefresh);
+        assertNull(conf.poolConfig);
+    }
+
+    @Test
+    public void testMandatoryFields() throws URISyntaxException {
+        RedisFeatureStoreBuilder conf = new RedisFeatureStoreBuilder("http", "host", 1234, 1);
+        assertEquals(new URI("http://host:1234"), conf.uri);
+        assertEquals(1, conf.cacheTimeSecs);
+    }
+
+    @Test
+    public void testMandatoryFieldsWithAlternateConstructor() throws URISyntaxException {
+        URI expectedURI = new URI("http://host:1234");
+        RedisFeatureStoreBuilder conf = new RedisFeatureStoreBuilder(expectedURI, 1);
+        assertEquals(expectedURI, conf.uri);
+        assertEquals(1, conf.cacheTimeSecs);
+    }
+
+    @Test
+    public void testRefreshStaleValues() throws URISyntaxException {
+        URI expectedURI = new URI("http://host:1234");
+        RedisFeatureStoreBuilder conf = new RedisFeatureStoreBuilder(expectedURI, 1).refreshStaleValues(true);
+        assertEquals(true, conf.refreshStaleValues);
+    }
+
+    @Test
+    public void testAsyncRefresh() throws URISyntaxException {
+        URI expectedURI = new URI("http://host:1234");
+        RedisFeatureStoreBuilder conf = new RedisFeatureStoreBuilder(expectedURI, 1).asyncRefresh(true);
+        assertEquals(true, conf.asyncRefresh);
+    }
+
+    @Test
+    public void testPrefixConfigured() throws URISyntaxException {
+        RedisFeatureStoreBuilder conf = new RedisFeatureStoreBuilder("http", "host", 1234, 1).prefix("prefix");
+        assertEquals("prefix", conf.prefix);
+    }
+
+    @Test
+    public void testConnectTimeoutConfigured() throws URISyntaxException {
+        RedisFeatureStoreBuilder conf = new RedisFeatureStoreBuilder("http", "host", 1234, 1).connectTimeout(1, TimeUnit.SECONDS);
+        assertEquals(1000, conf.connectTimeout);
+    }
+
+    @Test
+    public void testSocketTimeoutConfigured() throws URISyntaxException {
+        RedisFeatureStoreBuilder conf = new RedisFeatureStoreBuilder("http", "host", 1234, 1).socketTimeout(1, TimeUnit.SECONDS);
+        assertEquals(1000, conf.socketTimeout);
+    }
+
+    @Test
+    public void testCacheTimeConfiguredInSeconds() throws URISyntaxException {
+        RedisFeatureStoreBuilder conf = new RedisFeatureStoreBuilder("http", "host", 1234, 1).cacheTime(2000, TimeUnit.MILLISECONDS);
+        assertEquals(2, conf.cacheTimeSecs);
+    }
+
+    @Test
+    public void testPoolConfigConfigured() throws URISyntaxException {
+        JedisPoolConfig poolConfig = new JedisPoolConfig();
+        RedisFeatureStoreBuilder conf = new RedisFeatureStoreBuilder("http", "host", 1234, 1).poolConfig(poolConfig);
+        assertEquals(poolConfig, conf.poolConfig);
+    }
+}


### PR DESCRIPTION
Added:
 - Configuration options to set the Jedis pool connection and socket timeouts in the `RedisFeatureStore`.
 - Support for 3 modes of `RedisFeatureStore` local cache behaviour; default evict, refresh and async refresh (see javadoc for more details on functionality).
 - A `RedisFeatureStoreConfig` with it's own builder. Deprecated the old constructors for the `RedisFeatureStore` (I was a little daring here - deprecation isn't necessary of course).
 - Tests for the `RedisFeatureStoreBuilder`.

**Summary of the change:**

We found that having the ability to set the conn and socket timeouts in the Jedis pool was useful to provide a lower hard limit on blocking refreshes. Given the default cache behaviour is a blocking expireAfterWrite (http://google.github.io/guava/releases/snapshot/api/docs/src-html/com/google/common/cache/CacheBuilder.html#line.623) - it's useful to be able to set these parameters to something lower than the default 2 seconds.

Additionally the new modes of cache operation are situationally quite useful. Specifically utilising the asynchronous refresh "mode" which decouples network I/O from stale values fully, returning the previously cached value (`FeatureRep<>`) in the meantime. This should theoretically provide a optimal local cache performance, at the cost of "greater" eventual consistency.

These additions were all backed by the introduction of a `RedisFeatureStoreBuilder` much like the LDClient one. This simplifies the constructor the of the `RedisFeatureStore` and improving it's flexibility and ease of construction.