### PR TITLE
Making FeatureRep and Variation public

### DIFF
--- a/src/main/java/com/launchdarkly/client/FeatureRep.java
+++ b/src/main/java/com/launchdarkly/client/FeatureRep.java
@@ -63,7 +63,7 @@ public class FeatureRep<E> {
     return result;
   }
 
-  FeatureRep(Builder<E> b) {
+  public FeatureRep(Builder<E> b) {
     this.name = b.name;
     this.key = b.key;
     this.salt = b.salt;
@@ -133,7 +133,7 @@ public class FeatureRep<E> {
       return null;
   }
 
-  static class Builder<E> {
+  public static class Builder<E> {
     private String name;
     private String key;
     private boolean on;
@@ -142,7 +142,7 @@ public class FeatureRep<E> {
     private int version;
     private List<Variation<E>> variations;
 
-    Builder(String name, String key) {
+    public Builder(String name, String key) {
       this.on = true;
       this.name = name;
       this.key = key;
@@ -150,32 +150,32 @@ public class FeatureRep<E> {
       this.variations = new ArrayList<>();
     }
 
-    Builder<E> salt(String s) {
+    public Builder<E> salt(String s) {
       this.salt = s;
       return this;
     }
 
-    Builder<E> on(boolean b) {
+    public Builder<E> on(boolean b) {
       this.on = b;
       return this;
     }
 
-    Builder<E> variation(Variation<E> v) {
+    public Builder<E> variation(Variation<E> v) {
       variations.add(v);
       return this;
     }
 
-    Builder<E> deleted(boolean d) {
+    public Builder<E> deleted(boolean d) {
       this.deleted = d;
       return this;
     }
 
-    Builder<E> version(int v) {
+    public Builder<E> version(int v) {
       this.version = v;
       return this;
     }
 
-    FeatureRep<E> build() {
+    public FeatureRep<E> build() {
       return new FeatureRep<>(this);
     }
 

--- a/src/main/java/com/launchdarkly/client/FeatureRep.java
+++ b/src/main/java/com/launchdarkly/client/FeatureRep.java
@@ -6,7 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-class FeatureRep<E> {
+public class FeatureRep<E> {
   String name;
   String key;
   String salt;

--- a/src/main/java/com/launchdarkly/client/Variation.java
+++ b/src/main/java/com/launchdarkly/client/Variation.java
@@ -82,36 +82,36 @@ public class Variation<E> {
     return false;
   }
 
-  static class Builder<E> {
+  public static class Builder<E> {
     E value;
     int weight;
     TargetRule userTarget;
     List<TargetRule> targets;
 
-    Builder(E value, int weight) {
+    public Builder(E value, int weight) {
       this.value = value;
       this.weight = weight;
       this.userTarget = new TargetRule("key", "in", new ArrayList<JsonPrimitive>());
       targets = new ArrayList<>();
     }
 
-    Builder<E> userTarget(TargetRule rule) {
+    public Builder<E> userTarget(TargetRule rule) {
       this.userTarget = rule;
       return this;
     }
 
-    Builder<E> target(TargetRule rule) {
+    public Builder<E> target(TargetRule rule) {
       targets.add(rule);
       return this;
     }
 
-    Variation<E> build() {
+    public Variation<E> build() {
       return new Variation<>(this);
     }
 
   }
 
-  static class TargetRule {
+  public static class TargetRule {
     String attribute;
     String operator;
     List<JsonPrimitive> values;
@@ -122,13 +122,13 @@ public class Variation<E> {
 
     }
 
-    TargetRule(String attribute, String operator, List<JsonPrimitive> values) {
+    public TargetRule(String attribute, String operator, List<JsonPrimitive> values) {
       this.attribute = attribute;
       this.operator = operator;
       this.values = new ArrayList<>(values);
     }
 
-    TargetRule(String attribute, List<JsonPrimitive> values) {
+    public TargetRule(String attribute, List<JsonPrimitive> values) {
       this(attribute, "in", values);
     }
 

--- a/src/main/java/com/launchdarkly/client/Variation.java
+++ b/src/main/java/com/launchdarkly/client/Variation.java
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.List;
 
-class Variation<E> {
+public class Variation<E> {
   E value;
   int weight;
   TargetRule userTarget;


### PR DESCRIPTION
We have interest in using the `InMemoryFeatureStore` for testing and local development purposes, however the public API of the store (for writing values) depends on the default scope (package private) `FeatureRep<E>` class. 

Looking at history the previous reason was to "Give reps default scope so they don't pollute javadoc" (see: https://github.com/launchdarkly/java-client/commit/765db3d33d5819dc9917fcf487a31aa2ce3b2077). 

Is this still a strong enough reason to make them default scoped? Is there something better we could do other than making reps public?

This change also makes `Variation<>` public for similar reasons.

Edit: Okay a bunch of other stuff fell forward with this change - I also made `Variation`s, `TargetRule`s and their associated Builders public.

Quite a bit ended up changing here - if wish to keep these package private I will perhaps look at other options to solve our use cases (like for example; adding a FeatureStore which takes a map of key values instead).