### PR TITLE
Added a "TestFeatureStore"

### DIFF
--- a/src/main/java/com/launchdarkly/client/TestFeatureStore.java
+++ b/src/main/java/com/launchdarkly/client/TestFeatureStore.java
@@ -1,0 +1,40 @@
+package com.launchdarkly.client;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A decorated {@link InMemoryFeatureStore} which provides functionality to create (or override) "on" or "off" feature flags for all users.
+ *
+ * Using this store is useful for testing purposes when you want to have runtime support for turning specific features "on" or "off".
+ *
+ */
+public class TestFeatureStore extends InMemoryFeatureStore {
+
+    private AtomicInteger version = new AtomicInteger(0);
+
+    /**
+     * Turns a feature, identified by key, "on" for every user. If the feature rules already exist in the store then it will override it to be "on" for every {@link LDUser}.
+     * If the feature rule is not currently in the store, it will create one that is "on" for every {@link LDUser}.
+     *
+     * @param key the key of the feature flag to be "on".
+     */
+    public void turnFeatureOn(String key) {
+        writeFeatureRep(key, new Variation.Builder<>(true, 100).build());
+    }
+
+    /**
+     * Turns a feature, identified by key, "off" for every user. If the feature rules already exists in the store then it will override it to be "off" for every {@link LDUser}.
+     * If the feature rule is not currently in the store, it will create one that is "off" for every {@link LDUser}.
+     *
+     * @param key the key of the feature flag to be "off".
+     */
+    public void turnFeatureOff(String key) {
+        writeFeatureRep(key, new Variation.Builder<>(false, 100).build());
+    }
+
+    private void writeFeatureRep(final String key, final Variation<Boolean> variation) {
+        FeatureRep<Boolean> newFeature = new FeatureRep.Builder<Boolean>(String.format("test-%s", key), key)
+                .variation(variation).version(version.incrementAndGet()).build();
+        upsert(key, newFeature);
+    }
+}


### PR DESCRIPTION
So running off the tail of https://github.com/launchdarkly/java-client/pull/50 - this is a slightly different approach which doesn't expose reps. Using something like this `TestFeatureStore` would allow users to configure the `LDClient` in a way that allows them to internally creates to be 100% "on" or "off" without any direct dependency on the rulesets coming from LD (e.g. configure it to also be .stream(false), etc).

This allows for runtime flipping of the flag values (with a reference to the configured `TestFeatureStore`) in test environments (e.g. perhaps where mocking is not viable), amongst other possibilities which don't want to depend on an external source of the flag rulesets. The primary desired comes from, for example, integration environments where rapidly changing the flag values via the API would be expensive.

The API / implementation is a bit rough and I want to open it up as is for discussion to see if this seems like a sensible way to go (especially with future incoming changes, etc) - or perhaps of a better alternative altogether?