### PR TITLE
Evaluate "interpreted" attributes when they are set as custom attributes.

### DIFF
--- a/src/main/java/com/launchdarkly/client/Variation.java
+++ b/src/main/java/com/launchdarkly/client/Variation.java
@@ -179,7 +179,9 @@ class Variation<E> {
           uValue = user.getAnonymous();
         }
       }
-      else { // Custom attribute
+
+      // Always check custom attributes in case interpreted keys were used here
+      if (uValue == null) { // Custom attribute
         JsonElement custom = user.getCustom(attribute);
 
         if (custom != null) {

--- a/src/test/java/com/launchdarkly/client/FeatureRepTest.java
+++ b/src/test/java/com/launchdarkly/client/FeatureRepTest.java
@@ -28,6 +28,8 @@ public class FeatureRepTest {
 
   private final Variation.TargetRule targetAnonymousOn = new Variation.TargetRule("anonymous", Collections.singletonList(new JsonPrimitive(true)));
 
+  private final Variation.TargetRule targetEmailOn = new Variation.TargetRule("email", Collections.singletonList(new JsonPrimitive("test@test.com")));
+
   private final Variation<Boolean> trueVariation = new Variation.Builder<>(true, 80)
       .target(targetUserOn)
       .target(targetGroupOn)
@@ -42,6 +44,17 @@ public class FeatureRepTest {
       .target(targetFavoriteNumberOff)
       .target(targetLikesDogsOff)
       .build();
+
+  private final Variation<Boolean> emailOnlyVariation = new Variation.Builder<>(true, 0)
+          .target(targetEmailOn)
+          .build();
+
+  private final FeatureRep<Boolean> emailRuleFlag = new FeatureRep.Builder<Boolean>("Email rule flag", "email.rule.flag")
+          .on(true)
+          .salt("feefifofum")
+          .variation(emailOnlyVariation)
+          .build();
+
 
   private final FeatureRep<Boolean> simpleFlag = new FeatureRep.Builder<Boolean>("Sample flag", "sample.flag")
       .on(true)
@@ -199,6 +212,17 @@ public class FeatureRepTest {
 
     Boolean b = simpleFlag.evaluate(user);
     assertEquals(true, b);
+  }
+
+  @Test
+  public void testInterpretedAttributeEvaluatesInCustom() {
+    LDUser customEmailSetUser = new LDUser.Builder("randomOtherUser@test.com").custom("email", "test@test.com").build();
+    Boolean b = emailRuleFlag.evaluate(customEmailSetUser);
+    assertEquals(true, b);
+
+    LDUser interpretedEmailSetUser = new LDUser.Builder("randomOtherUser@test.com").email("test@test.com").build();
+    Boolean b2 = emailRuleFlag.evaluate(interpretedEmailSetUser);
+    assertEquals(true, b2);
   }
 
 }


### PR DESCRIPTION
An interesting situation arose where if you don't set "interpreted" attributes via the special builder methods in `LDUser` they are not evaluated at all (e.g. when set via `.custom()`). I found this a little counterintuitive because it was not immediately obvious - or explicit that this was the case via the documentation / javadoc.

This change adds the ability to also evaluate them if a user sets an "interpreted" special attribute via custom. It implicitly also allows you to evaluate against a list of them like other custom attributes.

I am not sure if there was a deliberate reason for choosing to *only* make them evaluate if set via the dedicated methods. I noticed the same thing happens in other clients: https://github.com/launchdarkly/python-client/blob/master/ldclient/util.py#L69

If there is a good reason for not allowing this fallback - then I would suggest an update to documentation to more explicitly cover which fields are considered "interpreted" / "special" / "builtin" so it's less easy to fall into this situation.