### PR TITLE
Final v2 changes.

### DIFF
--- a/src/main/java/com/launchdarkly/client/FeatureFlag.java
+++ b/src/main/java/com/launchdarkly/client/FeatureFlag.java
@@ -53,11 +53,13 @@ class FeatureFlag {
   }
 
   EvalResult evaluate(LDUser user, FeatureStore featureStore) throws EvaluationException {
-    if (user == null || user.getKeyAsString().isEmpty()) {
-      logger.warn("Null user or null/empty user key when evaluating flag: " + key + "; returning null");
-      return null;
-    }
     List<FeatureRequestEvent> prereqEvents = new ArrayList<>();
+
+    if (user == null || user.getKey() == null) {
+      logger.warn("Null user or null user key when evaluating flag: " + key + "; returning null");
+      return new EvalResult(null, prereqEvents);
+    }
+
     if (isOn()) {
       JsonElement value = evaluate(user, featureStore, prereqEvents);
       if (value != null) {

--- a/src/main/java/com/launchdarkly/client/FeatureRequestor.java
+++ b/src/main/java/com/launchdarkly/client/FeatureRequestor.java
@@ -55,7 +55,7 @@ class FeatureRequestor {
     return client;
   }
 
-  Map<String, FeatureFlag> makeAllRequest() throws IOException {
+  Map<String, FeatureFlag> getAllFlags() throws IOException {
     HttpCacheContext context = HttpCacheContext.create();
 
     HttpGet request = config.getRequest(sdkKey, GET_LATEST_FLAGS_PATH);
@@ -102,13 +102,9 @@ class FeatureRequestor {
     }
   }
 
-  FeatureFlag makeRequest(String featureKey, boolean latest) throws IOException {
+  FeatureFlag getFlag(String featureKey) throws IOException {
     HttpCacheContext context = HttpCacheContext.create();
-
-    String resource = latest ? "/api/eval/latest-features/" : "/api/eval/features/";
-
-    HttpGet request = config.getRequest(sdkKey,resource + featureKey);
-
+    HttpGet request = config.getRequest(sdkKey, GET_LATEST_FLAGS_PATH + "/" + featureKey);
     CloseableHttpResponse response = null;
     try {
       response = client.execute(request, context);

--- a/src/main/java/com/launchdarkly/client/LDClient.java
+++ b/src/main/java/com/launchdarkly/client/LDClient.java
@@ -132,8 +132,8 @@ public class LDClient implements Closeable {
     if (isOffline()) {
       return;
     }
-    if (user == null || user.getKeyAsString().isEmpty()) {
-      logger.warn("Track called with empty/nil user or user key!");
+    if (user == null || user.getKey() == null) {
+      logger.warn("Track called with null user or null user key!");
     }
     boolean processed = eventProcessor.sendEvent(new CustomEvent(eventName, user, data));
     if (!processed) {
@@ -163,8 +163,8 @@ public class LDClient implements Closeable {
     if (isOffline()) {
       return;
     }
-    if (user == null || user.getKeyAsString().isEmpty()) {
-      logger.warn("Identify called with empty/nil user or user key!");
+    if (user == null || user.getKey() == null) {
+      logger.warn("Identify called with null user or null user key!");
     }
     boolean processed = eventProcessor.sendEvent(new IdentifyEvent(user));
     if (!processed) {
@@ -205,8 +205,8 @@ public class LDClient implements Closeable {
       return null;
     }
 
-    if (user == null || user.getKeyAsString().isEmpty()) {
-      logger.warn("allFlags() was called with null user or null/empty user key! returning null");
+    if (user == null || user.getKey() == null) {
+      logger.warn("allFlags() was called with null user or null user key! returning null");
       return null;
     }
 
@@ -315,8 +315,8 @@ public class LDClient implements Closeable {
   }
 
   private JsonElement evaluate(String featureKey, LDUser user, JsonElement defaultValue) {
-    if (user == null || user.getKeyAsString().isEmpty()) {
-      logger.warn("Null user or null/empty user key when evaluating flag: " + featureKey + "; returning default value");
+    if (user == null || user.getKey() == null) {
+      logger.warn("Null user or null user key when evaluating flag: " + featureKey + "; returning default value");
       sendFlagRequestEvent(featureKey, user, defaultValue, defaultValue, null);
       return defaultValue;
     }
@@ -386,7 +386,7 @@ public class LDClient implements Closeable {
    * @return the hash, or null if the hash could not be calculated.
      */
   public String secureModeHash(LDUser user) {
-    if (user == null || user.getKeyAsString().isEmpty()) {
+    if (user == null || user.getKey() == null) {
       return null;
     }
     try {

--- a/src/main/java/com/launchdarkly/client/LDClientInterface.java
+++ b/src/main/java/com/launchdarkly/client/LDClientInterface.java
@@ -1,0 +1,41 @@
+package com.launchdarkly.client;
+
+import com.google.gson.JsonElement;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+
+public interface LDClientInterface extends Closeable {
+  boolean initialized();
+
+  void track(String eventName, LDUser user, JsonElement data);
+
+  void track(String eventName, LDUser user);
+
+  void identify(LDUser user);
+
+  Map<String, JsonElement> allFlags(LDUser user);
+
+  boolean boolVariation(String featureKey, LDUser user, boolean defaultValue);
+
+  @Deprecated
+  boolean toggle(String featureKey, LDUser user, boolean defaultValue);
+
+  Integer intVariation(String featureKey, LDUser user, int defaultValue);
+
+  Double doubleVariation(String featureKey, LDUser user, Double defaultValue);
+
+  String stringVariation(String featureKey, LDUser user, String defaultValue);
+
+  JsonElement jsonVariation(String featureKey, LDUser user, JsonElement defaultValue);
+
+  @Override
+  void close() throws IOException;
+
+  void flush();
+
+  boolean isOffline();
+
+  String secureModeHash(LDUser user);
+}

--- a/src/main/java/com/launchdarkly/client/PollingProcessor.java
+++ b/src/main/java/com/launchdarkly/client/PollingProcessor.java
@@ -48,7 +48,7 @@ public class PollingProcessor implements UpdateProcessor {
       @Override
       public void run() {
         try {
-          store.init(requestor.makeAllRequest());
+          store.init(requestor.getAllFlags());
           if (!initialized.getAndSet(true)) {
             logger.info("Initialized LaunchDarkly client.");
             initFuture.completed(null);

--- a/src/main/java/com/launchdarkly/client/RedisFeatureStore.java
+++ b/src/main/java/com/launchdarkly/client/RedisFeatureStore.java
@@ -240,8 +240,10 @@ public class RedisFeatureStore implements FeatureStore {
       Type type = new TypeToken<FeatureFlag>() {}.getType();
 
       for (Map.Entry<String, String> entry : featuresJson.entrySet()) {
-        FeatureFlag rep =  gson.fromJson(entry.getValue(), type);
-        result.put(entry.getKey(), rep);
+        FeatureFlag featureFlag =  gson.fromJson(entry.getValue(), type);
+        if (!featureFlag.isDeleted()){
+          result.put(entry.getKey(), featureFlag);
+        }
       }
       return result;
     }

--- a/src/main/java/com/launchdarkly/client/StreamProcessor.java
+++ b/src/main/java/com/launchdarkly/client/StreamProcessor.java
@@ -76,7 +76,7 @@ class StreamProcessor implements UpdateProcessor {
           }
           case INDIRECT_PUT:
             try {
-              store.init(requestor.makeAllRequest());
+              store.init(requestor.getAllFlags());
               if (!initialized.getAndSet(true)) {
                 initFuture.completed(null);
                 logger.info("Initialized LaunchDarkly client.");
@@ -88,7 +88,7 @@ class StreamProcessor implements UpdateProcessor {
           case INDIRECT_PATCH:
             String key = event.getData();
             try {
-              FeatureFlag feature = requestor.makeRequest(key, true);
+              FeatureFlag feature = requestor.getFlag(key);
               store.upsert(key, feature);
             } catch (IOException e) {
               logger.error("Encountered exception in LaunchDarkly client", e);

--- a/src/main/java/com/launchdarkly/client/VariationType.java
+++ b/src/main/java/com/launchdarkly/client/VariationType.java
@@ -1,0 +1,50 @@
+package com.launchdarkly.client;
+
+
+import com.google.gson.JsonElement;
+
+public enum VariationType {
+  Boolean {
+    @Override
+    void assertResultType(JsonElement result) throws EvaluationException {
+      if (result.isJsonPrimitive() && result.getAsJsonPrimitive().isBoolean()) {
+        return;
+      }
+      throw new EvaluationException("Feature flag evaluation expected result as boolean type, but got non-boolean type.");
+    }
+  },
+  Integer {
+    @Override
+    void assertResultType(JsonElement result) throws EvaluationException {
+      if (result.isJsonPrimitive() && result.getAsJsonPrimitive().isNumber()) {
+        return;
+      }
+      throw new EvaluationException("Feature flag evaluation expected result as number type, but got non-number type.");
+    }
+  },
+  Double {
+    @Override
+    void assertResultType(JsonElement result) throws EvaluationException {
+      if (result.isJsonPrimitive() && result.getAsJsonPrimitive().isNumber()) {
+        return;
+      }
+      throw new EvaluationException("Feature flag evaluation expected result as number type, but got non-number type.");
+    }
+  },
+  String {
+    @Override
+    void assertResultType(JsonElement result) throws EvaluationException {
+      if (result.isJsonPrimitive() && result.getAsJsonPrimitive().isString()) {
+        return;
+      }
+      throw new EvaluationException("Feature flag evaluation expected result as string type, but got non-string type.");
+    }
+  },
+  Json {
+    @Override
+    void assertResultType(JsonElement result) {
+    }
+  };
+
+  abstract void assertResultType(JsonElement result) throws EvaluationException;
+}

--- a/src/test/java/com/launchdarkly/client/LDClientTest.java
+++ b/src/test/java/com/launchdarkly/client/LDClientTest.java
@@ -24,7 +24,7 @@ public class LDClientTest extends EasyMockSupport {
   private PollingProcessor pollingProcessor;
   private EventProcessor eventProcessor;
   private Future initFuture;
-  private LDClient client;
+  private LDClientInterface client;
 
   @Before
   public void before() {
@@ -346,7 +346,7 @@ public class LDClientTest extends EasyMockSupport {
     LDConfig config = new LDConfig.Builder()
             .offline(true)
             .build();
-    LDClient client = new LDClient("secret", config);
+    LDClientInterface client = new LDClient("secret", config);
     LDUser user = new LDUser.Builder("Message").build();
     assertEquals("aa747c502a898200f9e4fa21bac68136f886a0e27aec70ba06daf2e2a5cb5597", client.secureModeHash(user));
   }
@@ -356,7 +356,7 @@ public class LDClientTest extends EasyMockSupport {
     assertEquals(true, result);
   }
 
-  private LDClient createMockClient(LDConfig config) {
+  private LDClientInterface createMockClient(LDConfig config) {
     return new LDClient("SDK_KEY", config) {
       @Override
       protected FeatureRequestor createFeatureRequestor(String sdkKey, LDConfig config) {

--- a/src/test/java/com/launchdarkly/client/PollingProcessorTest.java
+++ b/src/test/java/com/launchdarkly/client/PollingProcessorTest.java
@@ -20,7 +20,7 @@ public class PollingProcessorTest extends EasyMockSupport {
     FeatureRequestor requestor = createStrictMock(FeatureRequestor.class);
     PollingProcessor pollingProcessor = new PollingProcessor(LDConfig.DEFAULT, requestor);
 
-    expect(requestor.makeAllRequest())
+    expect(requestor.getAllFlags())
         .andReturn(new HashMap<String, FeatureFlag>())
         .once();
     replayAll();
@@ -37,7 +37,7 @@ public class PollingProcessorTest extends EasyMockSupport {
     FeatureRequestor requestor = createStrictMock(FeatureRequestor.class);
     PollingProcessor pollingProcessor = new PollingProcessor(LDConfig.DEFAULT, requestor);
 
-    expect(requestor.makeAllRequest())
+    expect(requestor.getAllFlags())
         .andThrow(new IOException("This exception is part of a test and yes you should be seeing it."))
         .once();
     replayAll();


### PR DESCRIPTION
Allow blank user key when evaluating. 
Extract client interface. 
No longer return null when expected type does not match variation from evaluation.