### PR TITLE
Propagate proxy configuration to okhttp client

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
 
 allprojects {
     group = 'com.launchdarkly'
-    version = "2.0.8"
+    version = "2.0.9-SNAPSHOT"
     sourceCompatibility = 1.7
     targetCompatibility = 1.7
 }
@@ -32,7 +32,7 @@ dependencies {
     compile "com.google.guava:guava:19.0"
     compile "joda-time:joda-time:2.9.3"
     compile "org.slf4j:slf4j-api:1.7.21"
-    compile group: "com.launchdarkly", name: "okhttp-eventsource", version: "1.0.0", changing: true
+    compile group: "com.launchdarkly", name: "okhttp-eventsource", version: "1.1.0", changing: true
     compile "redis.clients:jedis:2.9.0"
     testCompile "org.easymock:easymock:3.4"
     testCompile 'junit:junit:4.12'


### PR DESCRIPTION
When a proxy is configured with `LDConfig`, the settings need to be propagated to the `okhttp` client used by `StreamProcessor`.