### PR TITLE
Consider improving LDUser::getValueForEvaluation performance for cust…

### DIFF
--- a/src/main/java/com/launchdarkly/client/LDUser.java
+++ b/src/main/java/com/launchdarkly/client/LDUser.java
@@ -71,10 +71,14 @@ public class LDUser {
   }
 
   protected JsonElement getValueForEvaluation(String attribute) {
+    JsonElement returnVal = getCustom(attribute);
+    if (returnVal != null) {
+      return returnVal;
+    }
     try {
       return UserAttribute.valueOf(attribute).get(this);
     } catch (IllegalArgumentException expected) {
-      return getCustom(attribute);
+      return null;
     }
   }
 
@@ -127,7 +131,7 @@ public class LDUser {
   }
 
   JsonElement getCustom(String key) {
-    if (custom != null) {
+    if (custom != null && !custom.isEmpty()) {
       return custom.get(key);
     }
     return null;


### PR DESCRIPTION
For custom attributes, currently {{LDUSer::getValueForEvaluation}} checks for {{UserAttribute}} first and moves on to check "custom" attributes.

As a part of this, it always encounters "IllegalArguementException" which ends up populating the entire stacktrace (which could be 100s in size). This turns out to be very expensive depending on the number of calls.

It would be good consider, where custom attributes are checked first and then check the user attribute. This way, we do not need to pay the penalty of filling up the stack trace for every call involving custom attribute.