### PR TITLE
Using murmur3 instead of SHA1

### DIFF
--- a/src/main/java/com/launchdarkly/client/VariationOrRollout.java
+++ b/src/main/java/com/launchdarkly/client/VariationOrRollout.java
@@ -1,9 +1,11 @@
 package com.launchdarkly.client;
 
 
+import com.google.common.hash.Hashing;
 import com.google.gson.JsonElement;
 import org.apache.commons.codec.digest.DigestUtils;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 /**
@@ -48,8 +50,10 @@ class VariationOrRollout {
       if (user.getSecondary() != null) {
         idHash = idHash + "." + user.getSecondary().getAsString();
       }
-      String hash = DigestUtils.sha1Hex(key + "." + salt + "." + idHash).substring(0, 15);
-      long longVal = Long.parseLong(hash, 16);
+      String murmur3Hash = Hashing.murmur3_128()
+          .hashString((key + "." + salt + "." + idHash), StandardCharsets.UTF_8)
+          .toString().substring(0, 15);
+      long longVal = Long.parseLong(murmur3Hash, 16);
       return (float) longVal / long_scale;
     }
     return 0F;


### PR DESCRIPTION
Murmur3 is a lot more CPU optimized than SHA1. Here is a microbenchmark based on my mac book which shows > 70% throughput improvement. Guava already supports Murmur3 and sha1 is deprecated in apache common codec as well.

> 
Benchmark                       Mode  Cnt     Score     Error   Units
HashBenchmark.testWithMurmur3  thrpt    5  2399.574 ± 481.923  ops/ms
HashBenchmark.testWithSHA1     thrpt    5  1361.255 ± 495.623  ops/ms
> 