### PR TITLE
prepare 3.0.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ All notable changes to the LaunchDarkly Java SDK will be documented in this file
 _This release was broken and should not be used._
 
 
+## [2.6.1] - 2018-03-01
+### Fixed
+- Improved performance when evaluating flags with custom attributes, by avoiding an unnecessary caught exception (thanks, [rbalamohan](https://github.com/launchdarkly/java-client/issues/113)).
+
+
 ## [2.6.0] - 2018-02-12
 ## Added
 - Adds support for a future LaunchDarkly feature, coming soon: semantic version user attributes.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=3.0.2
+version=3.0.3
 ossrhUsername=
 ossrhPassword=

--- a/src/main/java/com/launchdarkly/client/Clause.java
+++ b/src/main/java/com/launchdarkly/client/Clause.java
@@ -75,9 +75,11 @@ class Clause {
   }
   
   private boolean matchAny(JsonPrimitive userValue) {
-    for (JsonPrimitive v : values) {
-      if (op.apply(userValue, v)) {
-        return true;
+    if (op != null) {
+      for (JsonPrimitive v : values) {
+        if (op.apply(userValue, v)) {
+          return true;
+        }
       }
     }
     return false;

--- a/src/main/java/com/launchdarkly/client/FeatureFlagBuilder.java
+++ b/src/main/java/com/launchdarkly/client/FeatureFlagBuilder.java
@@ -3,6 +3,7 @@ package com.launchdarkly.client;
 import com.google.gson.JsonElement;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 class FeatureFlagBuilder {
@@ -84,6 +85,10 @@ class FeatureFlagBuilder {
     return this;
   }
 
+  FeatureFlagBuilder variations(JsonElement... variations) {
+    return variations(Arrays.asList(variations));
+  }
+  
   FeatureFlagBuilder deleted(boolean deleted) {
     this.deleted = deleted;
     return this;

--- a/src/main/java/com/launchdarkly/client/RedisFeatureStore.java
+++ b/src/main/java/com/launchdarkly/client/RedisFeatureStore.java
@@ -246,7 +246,7 @@ public class RedisFeatureStore implements FeatureStore {
         VersionedData oldItem = getRedisEvenIfDeleted(kind, newItem.getKey(), jedis);
   
         if (oldItem != null && oldItem.getVersion() >= newItem.getVersion()) {
-          logger.warn("Attempted to {} key: {} version: {}" +
+          logger.debug("Attempted to {} key: {} version: {}" +
               " with a version that is the same or older: {} in \"{}\"",
               newItem.isDeleted() ? "delete" : "update",
               newItem.getKey(), oldItem.getVersion(), newItem.getVersion(), kind.getNamespace());

--- a/src/main/java/com/launchdarkly/client/RedisFeatureStoreBuilder.java
+++ b/src/main/java/com/launchdarkly/client/RedisFeatureStoreBuilder.java
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit;
  * {@link RedisFeatureStoreBuilder} calls can be chained, enabling the following pattern:
  *
  * <pre>
- * RedisFeatureStoreBuilder builder = new RedisFeatureStoreBuilder("host", 443, 60)
+ * RedisFeatureStore store = new RedisFeatureStoreBuilder("host", 443, 60)
  *      .refreshStaleValues(true)
  *      .asyncRefresh(true)
  *      .socketTimeout(200)

--- a/src/test/java/com/launchdarkly/client/FeatureFlagTest.java
+++ b/src/test/java/com/launchdarkly/client/FeatureFlagTest.java
@@ -1,20 +1,24 @@
 package com.launchdarkly.client;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonPrimitive;
-
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
 
+import static com.launchdarkly.client.TestUtil.booleanFlagWithClauses;
+import static com.launchdarkly.client.TestUtil.fallthroughVariation;
+import static com.launchdarkly.client.TestUtil.jbool;
+import static com.launchdarkly.client.TestUtil.jint;
+import static com.launchdarkly.client.TestUtil.js;
 import static com.launchdarkly.client.VersionedDataKind.FEATURES;
 import static com.launchdarkly.client.VersionedDataKind.SEGMENTS;
-import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class FeatureFlagTest {
 
+  private static LDUser BASE_USER = new LDUser.Builder("x").build();
+  
   private FeatureStore featureStore;
 
   @Before
@@ -23,51 +27,222 @@ public class FeatureFlagTest {
   }
 
   @Test
-  public void testPrereqDoesNotExist() throws EvaluationException {
-    String keyA = "keyA";
-    String keyB = "keyB";
-    FeatureFlag f1 = newFlagWithPrereq(keyA, keyB);
-
-    featureStore.upsert(FEATURES, f1);
-    LDUser user = new LDUser.Builder("userKey").build();
-    FeatureFlag.EvalResult actual = f1.evaluate(user, featureStore);
-
-    Assert.assertNull(actual.getValue());
-    Assert.assertNotNull(actual.getPrerequisiteEvents());
-    Assert.assertEquals(0, actual.getPrerequisiteEvents().size());
+  public void flagReturnsOffVariationIfFlagIsOff() throws Exception {
+    FeatureFlag f = new FeatureFlagBuilder("feature")
+        .on(false)
+        .offVariation(1)
+        .fallthrough(fallthroughVariation(0))
+        .variations(js("fall"), js("off"), js("on"))
+        .build();
+    FeatureFlag.EvalResult result = f.evaluate(BASE_USER, featureStore);
+    
+    assertEquals(js("off"), result.getValue());
+    assertEquals(0, result.getPrerequisiteEvents().size());
   }
 
   @Test
-  public void testPrereqCollectsEventsForPrereqs() throws EvaluationException {
-    String keyA = "keyA";
-    String keyB = "keyB";
-    String keyC = "keyC";
-    FeatureFlag flagA = newFlagWithPrereq(keyA, keyB);
-    FeatureFlag flagB = newFlagWithPrereq(keyB, keyC);
-    FeatureFlag flagC = newFlagOff(keyC);
-
-    featureStore.upsert(FEATURES, flagA);
-    featureStore.upsert(FEATURES, flagB);
-    featureStore.upsert(FEATURES, flagC);
-
-    LDUser user = new LDUser.Builder("userKey").build();
-
-    FeatureFlag.EvalResult flagAResult = flagA.evaluate(user, featureStore);
-    Assert.assertNotNull(flagAResult);
-    Assert.assertNull(flagAResult.getValue());
-    Assert.assertEquals(2, flagAResult.getPrerequisiteEvents().size());
-
-    FeatureFlag.EvalResult flagBResult = flagB.evaluate(user, featureStore);
-    Assert.assertNotNull(flagBResult);
-    Assert.assertNull(flagBResult.getValue());
-    Assert.assertEquals(1, flagBResult.getPrerequisiteEvents().size());
-
-    FeatureFlag.EvalResult flagCResult = flagC.evaluate(user, featureStore);
-    Assert.assertNotNull(flagCResult);
-    Assert.assertEquals(null, flagCResult.getValue());
-    Assert.assertEquals(0, flagCResult.getPrerequisiteEvents().size());
+  public void flagReturnsNullIfFlagIsOffAndOffVariationIsUnspecified() throws Exception {
+    FeatureFlag f = new FeatureFlagBuilder("feature")
+        .on(false)
+        .fallthrough(fallthroughVariation(0))
+        .variations(js("fall"), js("off"), js("on"))
+        .build();
+    FeatureFlag.EvalResult result = f.evaluate(BASE_USER, featureStore);
+    
+    assertNull(result.getValue());
+    assertEquals(0, result.getPrerequisiteEvents().size());
+  }
+  
+  @Test
+  public void flagReturnsOffVariationIfPrerequisiteIsNotFound() throws Exception {
+    FeatureFlag f0 = new FeatureFlagBuilder("feature0")
+        .on(true)
+        .prerequisites(Arrays.asList(new Prerequisite("feature1", 1)))
+        .fallthrough(fallthroughVariation(0))
+        .offVariation(1)
+        .variations(js("fall"), js("off"), js("on"))
+        .build();
+    FeatureFlag.EvalResult result = f0.evaluate(BASE_USER, featureStore);
+    
+    assertEquals(js("off"), result.getValue());
+    assertEquals(0, result.getPrerequisiteEvents().size());
+  }
+  
+  @Test
+  public void flagReturnsOffVariationAndEventIfPrerequisiteIsNotMet() throws Exception {
+    FeatureFlag f0 = new FeatureFlagBuilder("feature0")
+        .on(true)
+        .prerequisites(Arrays.asList(new Prerequisite("feature1", 1)))
+        .fallthrough(fallthroughVariation(0))
+        .offVariation(1)
+        .variations(js("fall"), js("off"), js("on"))
+        .version(1)
+        .build();
+    FeatureFlag f1 = new FeatureFlagBuilder("feature1")
+        .on(true)
+        .fallthrough(fallthroughVariation(0))
+        .variations(js("nogo"), js("go"))
+        .version(2)
+        .build();
+    featureStore.upsert(FEATURES, f1);        
+    FeatureFlag.EvalResult result = f0.evaluate(BASE_USER, featureStore);
+    
+    assertEquals(js("off"), result.getValue());
+    
+    assertEquals(1, result.getPrerequisiteEvents().size());
+    FeatureRequestEvent event = result.getPrerequisiteEvents().get(0);
+    assertEquals(f1.getKey(), event.key);
+    assertEquals("feature", event.kind);
+    assertEquals(js("nogo"), event.value);
+    assertEquals(f1.getVersion(), event.version.intValue());
+    assertEquals(f0.getKey(), event.prereqOf);
   }
 
+  @Test
+  public void flagReturnsFallthroughVariationAndEventIfPrerequisiteIsMetAndThereAreNoRules() throws Exception {
+    FeatureFlag f0 = new FeatureFlagBuilder("feature0")
+        .on(true)
+        .prerequisites(Arrays.asList(new Prerequisite("feature1", 1)))
+        .fallthrough(fallthroughVariation(0))
+        .offVariation(1)
+        .variations(js("fall"), js("off"), js("on"))
+        .version(1)
+        .build();
+    FeatureFlag f1 = new FeatureFlagBuilder("feature1")
+        .on(true)
+        .fallthrough(fallthroughVariation(1))
+        .variations(js("nogo"), js("go"))
+        .version(2)
+        .build();
+    featureStore.upsert(FEATURES, f1);        
+    FeatureFlag.EvalResult result = f0.evaluate(BASE_USER, featureStore);
+    
+    assertEquals(js("fall"), result.getValue());
+    assertEquals(1, result.getPrerequisiteEvents().size());
+    
+    FeatureRequestEvent event = result.getPrerequisiteEvents().get(0);
+    assertEquals(f1.getKey(), event.key);
+    assertEquals("feature", event.kind);
+    assertEquals(js("go"), event.value);
+    assertEquals(f1.getVersion(), event.version.intValue());
+    assertEquals(f0.getKey(), event.prereqOf);
+  }
+
+  @Test
+  public void multipleLevelsOfPrerequisitesProduceMultipleEvents() throws Exception {
+    FeatureFlag f0 = new FeatureFlagBuilder("feature0")
+        .on(true)
+        .prerequisites(Arrays.asList(new Prerequisite("feature1", 1)))
+        .fallthrough(fallthroughVariation(0))
+        .offVariation(1)
+        .variations(js("fall"), js("off"), js("on"))
+        .version(1)
+        .build();
+    FeatureFlag f1 = new FeatureFlagBuilder("feature1")
+        .on(true)
+        .prerequisites(Arrays.asList(new Prerequisite("feature2", 1)))
+        .fallthrough(fallthroughVariation(1))
+        .variations(js("nogo"), js("go"))
+        .version(2)
+        .build();
+    FeatureFlag f2 = new FeatureFlagBuilder("feature2")
+        .on(true)
+        .fallthrough(fallthroughVariation(1))
+        .variations(js("nogo"), js("go"))
+        .version(3)
+        .build();
+    featureStore.upsert(FEATURES, f1);        
+    featureStore.upsert(FEATURES, f2);        
+    FeatureFlag.EvalResult result = f0.evaluate(BASE_USER, featureStore);
+    
+    assertEquals(js("fall"), result.getValue());    
+    assertEquals(2, result.getPrerequisiteEvents().size());
+    
+    FeatureRequestEvent event0 = result.getPrerequisiteEvents().get(0);
+    assertEquals(f2.getKey(), event0.key);
+    assertEquals("feature", event0.kind);
+    assertEquals(js("go"), event0.value);
+    assertEquals(f2.getVersion(), event0.version.intValue());
+    assertEquals(f1.getKey(), event0.prereqOf);
+
+    FeatureRequestEvent event1 = result.getPrerequisiteEvents().get(1);
+    assertEquals(f1.getKey(), event1.key);
+    assertEquals("feature", event1.kind);
+    assertEquals(js("go"), event1.value);
+    assertEquals(f1.getVersion(), event1.version.intValue());
+    assertEquals(f0.getKey(), event1.prereqOf);
+  }
+  
+  @Test
+  public void flagMatchesUserFromTargets() throws Exception {
+    FeatureFlag f = new FeatureFlagBuilder("feature")
+        .on(true)
+        .targets(Arrays.asList(new Target(Arrays.asList("whoever", "userkey"), 2)))
+        .fallthrough(fallthroughVariation(0))
+        .offVariation(1)
+        .variations(js("fall"), js("off"), js("on"))
+        .build();
+    LDUser user = new LDUser.Builder("userkey").build();
+    FeatureFlag.EvalResult result = f.evaluate(user, featureStore);
+    
+    assertEquals(js("on"), result.getValue());
+    assertEquals(0, result.getPrerequisiteEvents().size());
+  }
+  
+  @Test
+  public void flagMatchesUserFromRules() throws Exception {
+    Clause clause = new Clause("key", Operator.in, Arrays.asList(js("userkey")), false);
+    Rule rule = new Rule(Arrays.asList(clause), 2, null);
+    FeatureFlag f = new FeatureFlagBuilder("feature")
+        .on(true)
+        .rules(Arrays.asList(rule))
+        .fallthrough(fallthroughVariation(0))
+        .offVariation(1)
+        .variations(js("fall"), js("off"), js("on"))
+        .build();
+    LDUser user = new LDUser.Builder("userkey").build();
+    FeatureFlag.EvalResult result = f.evaluate(user, featureStore);
+    
+    assertEquals(js("on"), result.getValue());
+    assertEquals(0, result.getPrerequisiteEvents().size());
+  }
+  
+  @Test
+  public void clauseCanMatchBuiltInAttribute() throws Exception {
+    Clause clause = new Clause("name", Operator.in, Arrays.asList(js("Bob")), false);
+    FeatureFlag f = booleanFlagWithClauses(clause);
+    LDUser user = new LDUser.Builder("key").name("Bob").build();
+    
+    assertEquals(jbool(true), f.evaluate(user, featureStore).getValue());
+  }
+  
+  @Test
+  public void clauseCanMatchCustomAttribute() throws Exception {
+    Clause clause = new Clause("legs", Operator.in, Arrays.asList(jint(4)), false);
+    FeatureFlag f = booleanFlagWithClauses(clause);
+    LDUser user = new LDUser.Builder("key").custom("legs", 4).build();
+    
+    assertEquals(jbool(true), f.evaluate(user, featureStore).getValue());
+  }
+  
+  @Test
+  public void clauseReturnsFalseForMissingAttribute() throws Exception {
+    Clause clause = new Clause("legs", Operator.in, Arrays.asList(jint(4)), false);
+    FeatureFlag f = booleanFlagWithClauses(clause);
+    LDUser user = new LDUser.Builder("key").name("Bob").build();
+    
+    assertEquals(jbool(false), f.evaluate(user, featureStore).getValue());
+  }
+  
+  @Test
+  public void clauseCanBeNegated() throws Exception {
+    Clause clause = new Clause("name", Operator.in, Arrays.asList(js("Bob")), true);
+    FeatureFlag f = booleanFlagWithClauses(clause);
+    LDUser user = new LDUser.Builder("key").name("Bob").build();
+    
+    assertEquals(jbool(false), f.evaluate(user, featureStore).getValue());
+  }
+  
   @Test
   public void testSegmentMatchClauseRetrievesSegmentFromStore() throws Exception {
     Segment segment = new Segment.Builder("segkey")
@@ -80,7 +255,7 @@ public class FeatureFlagTest {
     LDUser user = new LDUser.Builder("foo").build();
     
     FeatureFlag.EvalResult result = flag.evaluate(user, featureStore);
-    Assert.assertEquals(new JsonPrimitive(true), result.getValue());
+    assertEquals(jbool(true), result.getValue());
   }
 
   @Test
@@ -89,34 +264,11 @@ public class FeatureFlagTest {
     LDUser user = new LDUser.Builder("foo").build();
     
     FeatureFlag.EvalResult result = flag.evaluate(user, featureStore);
-    Assert.assertEquals(new JsonPrimitive(false), result.getValue());
+    assertEquals(jbool(false), result.getValue());
   }
-  
-  private FeatureFlag newFlagWithPrereq(String featureKey, String prereqKey) {
-    return new FeatureFlagBuilder(featureKey)
-        .prerequisites(singletonList(new Prerequisite(prereqKey, 0)))
-        .variations(Arrays.<JsonElement>asList(new JsonPrimitive(0), new JsonPrimitive(1)))
-        .fallthrough(new VariationOrRollout(0, null))
-        .on(true)
-        .build();
-  }
-
-  private FeatureFlag newFlagOff(String featureKey) {
-    return new FeatureFlagBuilder(featureKey)
-        .variations(Arrays.<JsonElement>asList(new JsonPrimitive(0), new JsonPrimitive(1)))
-        .fallthrough(new VariationOrRollout(0, null))
-        .on(false)
-        .build();
-  }
-  
+ 
   private FeatureFlag segmentMatchBooleanFlag(String segmentKey) {
-    Clause clause = new Clause("", Operator.segmentMatch, Arrays.asList(new JsonPrimitive(segmentKey)), false);
-    Rule rule = new Rule(Arrays.asList(clause), 1, null);
-    return new FeatureFlagBuilder("key")
-        .variations(Arrays.<JsonElement>asList(new JsonPrimitive(false), new JsonPrimitive(true)))
-        .fallthrough(new VariationOrRollout(0, null))
-        .on(true)
-        .rules(Arrays.asList(rule))
-        .build();
+    Clause clause = new Clause("", Operator.segmentMatch, Arrays.asList(js(segmentKey)), false);
+    return booleanFlagWithClauses(clause);
   }
 }

--- a/src/test/java/com/launchdarkly/client/FeatureFlagTest.java
+++ b/src/test/java/com/launchdarkly/client/FeatureFlagTest.java
@@ -1,5 +1,11 @@
 package com.launchdarkly.client;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -13,6 +19,7 @@ import static com.launchdarkly.client.TestUtil.js;
 import static com.launchdarkly.client.VersionedDataKind.FEATURES;
 import static com.launchdarkly.client.VersionedDataKind.SEGMENTS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 public class FeatureFlagTest {
@@ -241,6 +248,48 @@ public class FeatureFlagTest {
     LDUser user = new LDUser.Builder("key").name("Bob").build();
     
     assertEquals(jbool(false), f.evaluate(user, featureStore).getValue());
+  }
+  
+  @Test
+  public void clauseWithUnsupportedOperatorStringIsUnmarshalledWithNullOperator() throws Exception {
+    // This just verifies that GSON will give us a null in this case instead of throwing an exception,
+    // so we fail as gracefully as possible if a new operator type has been added in the application
+    // and the SDK hasn't been upgraded yet.
+    String badClauseJson = "{\"attribute\":\"name\",\"operator\":\"doesSomethingUnsupported\",\"values\":[\"x\"]}";
+    Gson gson = new Gson();
+    Clause clause = gson.fromJson(badClauseJson, Clause.class);
+    assertNotNull(clause);
+    
+    JsonElement json = gson.toJsonTree(clause);
+    String expectedJson = "{\"attribute\":\"name\",\"values\":[\"x\"],\"negate\":false}";
+    assertEquals(gson.fromJson(expectedJson, JsonElement.class), json);
+  }
+  
+  @Test
+  public void clauseWithNullOperatorDoesNotMatch() throws Exception {
+    Clause badClause = new Clause("name", null, Arrays.asList(js("Bob")), false);
+    FeatureFlag f = booleanFlagWithClauses(badClause);
+    LDUser user = new LDUser.Builder("key").name("Bob").build();
+    
+    assertEquals(jbool(false), f.evaluate(user, featureStore).getValue());
+  }
+  
+  @Test
+  public void clauseWithNullOperatorDoesNotStopSubsequentRuleFromMatching() throws Exception {
+    Clause badClause = new Clause("name", null, Arrays.asList(js("Bob")), false);
+    Rule badRule = new Rule(Arrays.asList(badClause), 1, null);
+    Clause goodClause = new Clause("name", Operator.in, Arrays.asList(js("Bob")), false);
+    Rule goodRule = new Rule(Arrays.asList(goodClause), 1, null);
+    FeatureFlag f = new FeatureFlagBuilder("feature")
+        .on(true)
+        .rules(Arrays.asList(badRule, goodRule))
+        .fallthrough(fallthroughVariation(0))
+        .offVariation(0)
+        .variations(jbool(false), jbool(true))
+        .build();
+    LDUser user = new LDUser.Builder("key").name("Bob").build();
+    
+    assertEquals(jbool(true), f.evaluate(user, featureStore).getValue());
   }
   
   @Test

--- a/src/test/java/com/launchdarkly/client/RedisFeatureStoreTest.java
+++ b/src/test/java/com/launchdarkly/client/RedisFeatureStoreTest.java
@@ -1,13 +1,83 @@
 package com.launchdarkly.client;
 
-import java.net.URI;
+import com.google.gson.Gson;
 
+import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.launchdarkly.client.VersionedDataKind.FEATURES;
+import static java.util.Collections.singletonMap;
+
+import redis.clients.jedis.Jedis;
 
 public class RedisFeatureStoreTest extends FeatureStoreTestBase<RedisFeatureStore> {
 
   @Before
   public void setup() {
     store = new RedisFeatureStoreBuilder(URI.create("redis://localhost:6379"), 10).build();
+  }
+  
+  @Test
+  public void handlesUpsertRaceConditionAgainstExternalClientWithLowerVersion() {
+    final Jedis otherClient = new Jedis("localhost");
+    try {
+      final FeatureFlag flag = new FeatureFlagBuilder("foo").version(1).build();
+      initStoreWithSingleFeature(store, flag);
+      
+      store.setUpdateListener(makeConcurrentModifier(otherClient, flag, 2, 4));
+      
+      FeatureFlag myVer = new FeatureFlagBuilder(flag).version(10).build();
+      store.upsert(FEATURES, myVer);
+      FeatureFlag result = store.get(FEATURES, feature1.getKey());
+      Assert.assertEquals(myVer.getVersion(), result.getVersion());
+    } finally {
+      otherClient.close();
+    }
+  }
+  
+  @Test
+  public void handlesUpsertRaceConditionAgainstExternalClientWithHigherVersion() {
+    final Jedis otherClient = new Jedis("localhost");
+    try {
+      final FeatureFlag flag = new FeatureFlagBuilder("foo").version(1).build();
+      initStoreWithSingleFeature(store, flag);
+      
+      store.setUpdateListener(makeConcurrentModifier(otherClient, flag, 3, 3));
+      
+      FeatureFlag myVer = new FeatureFlagBuilder(flag).version(2).build();
+      store.upsert(FEATURES, myVer);
+      FeatureFlag result = store.get(FEATURES, feature1.getKey());
+      Assert.assertEquals(3, result.getVersion());
+    } finally {
+      otherClient.close();
+    }
+  }
+  
+  private void initStoreWithSingleFeature(RedisFeatureStore store, FeatureFlag flag) {
+    Map<String, FeatureFlag> flags = singletonMap(flag.getKey(), flag);
+    Map<VersionedDataKind<?>, Map<String, ? extends VersionedData>> allData = new HashMap<>();
+    allData.put(FEATURES, flags);
+    store.init(allData);
+  }
+  
+  private RedisFeatureStore.UpdateListener makeConcurrentModifier(final Jedis otherClient, final FeatureFlag flag,
+    final int startVersion, final int endVersion) {
+    final Gson gson = new Gson();
+    return new RedisFeatureStore.UpdateListener() {
+      int versionCounter = startVersion;
+      @Override
+      public void aboutToUpdate(String baseKey, String itemKey) {
+        if (versionCounter <= endVersion) {
+          FeatureFlag newVer = new FeatureFlagBuilder(flag).version(versionCounter).build();
+          versionCounter++;
+          otherClient.hset(baseKey, flag.getKey(), gson.toJson(newVer));
+        }
+      }
+    };
   }
 }

--- a/src/test/java/com/launchdarkly/client/TestUtil.java
+++ b/src/test/java/com/launchdarkly/client/TestUtil.java
@@ -1,0 +1,35 @@
+package com.launchdarkly.client;
+
+import com.google.gson.JsonPrimitive;
+
+import java.util.Arrays;
+
+public class TestUtil {
+
+  public static JsonPrimitive js(String s) {
+    return new JsonPrimitive(s);
+  }
+
+  public static JsonPrimitive jint(int n) {
+    return new JsonPrimitive(n);
+  }
+  
+  public static JsonPrimitive jbool(boolean b) {
+    return new JsonPrimitive(b);
+  }
+  
+  public static VariationOrRollout fallthroughVariation(int variation) {
+    return new VariationOrRollout(variation, null);
+  }
+  
+  public static FeatureFlag booleanFlagWithClauses(Clause... clauses) {
+    Rule rule = new Rule(Arrays.asList(clauses), 1, null);
+    return new FeatureFlagBuilder("feature")
+        .on(true)
+        .rules(Arrays.asList(rule))
+        .fallthrough(fallthroughVariation(0))
+        .offVariation(0)
+        .variations(jbool(false), jbool(true))
+        .build();
+  }
+}


### PR DESCRIPTION
## [3.0.3] - 2018-03-26
### Fixed
* In the Redis feature store, fixed a synchronization problem that could cause a feature flag update to be missed if several of them happened in rapid succession.
* Fixed a bug that would cause a `NullPointerException` when trying to evaluate a flag rule that contained an unknown operator type. This could happen if you started using some recently added feature flag functionality in the LaunchDarkly application but had not yet upgraded the SDK to a version that supports that feature. In this case, it should now simply treat that rule as a non-match.

### Changed
* The log message "Attempted to update ... with a version that is the same or older" has been downgraded from `WARN` level to `DEBUG`. It can happen frequently in normal operation when the client is in streaming mode, and is not a cause for concern.