### PR TITLE
Use the streamUri argument, don't build a new one

### DIFF
--- a/src/main/java/com/launchdarkly/client/StreamProcessor.java
+++ b/src/main/java/com/launchdarkly/client/StreamProcessor.java
@@ -173,7 +173,7 @@ class StreamProcessor implements UpdateProcessor {
   @VisibleForTesting
   protected EventSource createEventSource(EventHandler handler, URI streamUri, ConnectionErrorHandler errorHandler,
                                           Headers headers) {
-    EventSource.Builder builder = new EventSource.Builder(handler, URI.create(config.streamURI.toASCIIString() + "/all"))
+    EventSource.Builder builder = new EventSource.Builder(handler, streamUri)
         .connectionErrorHandler(errorHandler)
         .headers(headers)
         .reconnectTimeMs(config.reconnectTimeMs)


### PR DESCRIPTION
It looks like the intent was to use the `streamUri` argument passed in the method instead of building a new one.