### PR TITLE
prepare 4.2.0 release

### DIFF
--- a/src/main/java/com/launchdarkly/client/Components.java
+++ b/src/main/java/com/launchdarkly/client/Components.java
@@ -113,7 +113,7 @@ public abstract class Components {
         FeatureRequestor requestor = new FeatureRequestor(sdkKey, config);
         if (config.stream) {
           logger.info("Enabling streaming API");
-          return new StreamProcessor(sdkKey, config, requestor, featureStore);
+          return new StreamProcessor(sdkKey, config, requestor, featureStore, null);
         } else {
           logger.info("Disabling streaming API");
           logger.warn("You should only disable the streaming API if instructed to do so by LaunchDarkly support");

--- a/src/main/java/com/launchdarkly/client/FeatureRequestor.java
+++ b/src/main/java/com/launchdarkly/client/FeatureRequestor.java
@@ -37,27 +37,27 @@ class FeatureRequestor {
     this.config = config;
   }
 
-  Map<String, FeatureFlag> getAllFlags() throws IOException, InvalidSDKKeyException {
+  Map<String, FeatureFlag> getAllFlags() throws IOException, HttpErrorException {
     String body = get(GET_LATEST_FLAGS_PATH);
     return FeatureFlag.fromJsonMap(config, body);
   }
 
-  FeatureFlag getFlag(String featureKey) throws IOException, InvalidSDKKeyException {
+  FeatureFlag getFlag(String featureKey) throws IOException, HttpErrorException {
     String body = get(GET_LATEST_FLAGS_PATH + "/" + featureKey);
     return FeatureFlag.fromJson(config, body);
   }
 
-  Map<String, Segment> getAllSegments() throws IOException, InvalidSDKKeyException {
+  Map<String, Segment> getAllSegments() throws IOException, HttpErrorException {
     String body = get(GET_LATEST_SEGMENTS_PATH);
     return Segment.fromJsonMap(config, body);
   }
 
-  Segment getSegment(String segmentKey) throws IOException, InvalidSDKKeyException {
+  Segment getSegment(String segmentKey) throws IOException, HttpErrorException {
     String body = get(GET_LATEST_SEGMENTS_PATH + "/" + segmentKey);
     return Segment.fromJson(config, body);
   }
 
-  AllData getAllData() throws IOException, InvalidSDKKeyException {
+  AllData getAllData() throws IOException, HttpErrorException {
     String body = get(GET_LATEST_ALL_PATH);
     return config.gson.fromJson(body, AllData.class);
   }
@@ -69,7 +69,7 @@ class FeatureRequestor {
     return ret;
   }
   
-  private String get(String path) throws IOException, InvalidSDKKeyException {
+  private String get(String path) throws IOException, HttpErrorException {
     Request request = getRequestBuilder(sdkKey)
         .url(config.baseURI.toString() + path)
         .get()
@@ -81,12 +81,7 @@ class FeatureRequestor {
       String body = response.body().string();
 
       if (!response.isSuccessful()) {
-        if (response.code() == 401) {
-          logger.error("[401] Invalid SDK key when accessing URI: " + request.url());
-          throw new InvalidSDKKeyException();
-        }
-        throw new IOException("Unexpected response when retrieving Feature Flag(s): " + response + " using url: "
-            + request.url() + " with body: " + body);
+        throw new HttpErrorException(response.code());
       }
       logger.debug("Get flag(s) response: " + response.toString() + " with body: " + body);
       logger.debug("Network response: " + response.networkResponse());
@@ -96,12 +91,6 @@ class FeatureRequestor {
       }
 
       return body;
-    }
-  }
-  
-  @SuppressWarnings("serial")
-  public static class InvalidSDKKeyException extends Exception {
-    public InvalidSDKKeyException() {
     }
   }
 }

--- a/src/main/java/com/launchdarkly/client/HttpErrorException.java
+++ b/src/main/java/com/launchdarkly/client/HttpErrorException.java
@@ -1,0 +1,15 @@
+package com.launchdarkly.client;
+
+@SuppressWarnings("serial")
+class HttpErrorException extends Exception {
+  private final int status;
+  
+  public HttpErrorException(int status) {
+    super("HTTP error " + status);
+    this.status = status;
+  }
+  
+  public int getStatus() {
+    return status;
+  }
+}

--- a/src/main/java/com/launchdarkly/client/LDClient.java
+++ b/src/main/java/com/launchdarkly/client/LDClient.java
@@ -97,6 +97,9 @@ public final class LDClient implements LDClientInterface {
       } catch (Exception e) {
         logger.error("Exception encountered waiting for LaunchDarkly client initialization", e);
       }
+      if (!updateProcessor.initialized()) {
+        logger.warn("LaunchDarkly client was not successfully initialized");
+      }
     }
   }
 

--- a/src/main/java/com/launchdarkly/client/LDConfig.java
+++ b/src/main/java/com/launchdarkly/client/LDConfig.java
@@ -113,7 +113,7 @@ public final class LDConfig {
         .connectTimeout(connectTimeoutMillis, TimeUnit.MILLISECONDS)
         .readTimeout(socketTimeoutMillis, TimeUnit.MILLISECONDS)
         .writeTimeout(socketTimeoutMillis, TimeUnit.MILLISECONDS)
-        .retryOnConnectionFailure(true);
+        .retryOnConnectionFailure(false); // we will implement our own retry logic
 
     // When streaming is enabled, http GETs made by FeatureRequester will
     // always guarantee a new flag state. So, disable http response caching

--- a/src/main/java/com/launchdarkly/client/LDUser.java
+++ b/src/main/java/com/launchdarkly/client/LDUser.java
@@ -608,11 +608,7 @@ public class LDUser {
      * @return the builder
      */
     public Builder custom(String k, String v) {
-      checkCustomAttribute(k);
-      if (k != null && v != null) {
-        custom.put(k, new JsonPrimitive(v));
-      }
-      return this;
+      return custom(k, v == null ? null : new JsonPrimitive(v));
     }
 
     /**
@@ -625,11 +621,7 @@ public class LDUser {
      * @return the builder
      */
     public Builder custom(String k, Number n) {
-      checkCustomAttribute(k);
-      if (k != null && n != null) {
-        custom.put(k, new JsonPrimitive(n));
-      }
-      return this;
+      return custom(k, n == null ? null : new JsonPrimitive(n));
     }
 
     /**
@@ -642,9 +634,22 @@ public class LDUser {
      * @return the builder
      */
     public Builder custom(String k, Boolean b) {
+      return custom(k, b == null ? null : new JsonPrimitive(b));
+    }
+
+    /**
+     * Add a custom attribute whose value can be any JSON type. When set to one of the
+     * <a href="http://docs.launchdarkly.com/docs/targeting-users#targeting-based-on-user-attributes">built-in
+     * user attribute keys</a>, this custom attribute will be ignored.
+     *
+     * @param k the key for the custom attribute
+     * @param v the value for the custom attribute
+     * @return the builder
+     */
+    public Builder custom(String k, JsonElement v) {
       checkCustomAttribute(k);
-      if (k != null && b != null) {
-        custom.put(k, new JsonPrimitive(b));
+      if (k != null && v != null) {
+        custom.put(k, v);
       }
       return this;
     }
@@ -757,6 +762,21 @@ public class LDUser {
       return custom(k, b);
     }
 
+    /**
+     * Add a custom attribute of any JSON type, that will not be sent back to LaunchDarkly.
+     * When set to one of the
+     * <a href="http://docs.launchdarkly.com/docs/targeting-users#targeting-based-on-user-attributes">built-in
+     * user attribute keys</a>, this custom attribute will be ignored.
+     *
+     * @param k the key for the custom attribute
+     * @param v the value for the custom attribute
+     * @return the builder
+     */
+    public Builder privateCustom(String k, JsonElement v) {
+      privateAttrNames.add(k);
+      return custom(k, v);
+    }
+    
     /**
      * Add a list of {@link java.lang.String}-valued custom attributes. When set to one of the
      * <a href="http://docs.launchdarkly.com/docs/targeting-users#targeting-based-on-user-attributes">

--- a/src/main/java/com/launchdarkly/client/PollingProcessor.java
+++ b/src/main/java/com/launchdarkly/client/PollingProcessor.java
@@ -58,6 +58,7 @@ class PollingProcessor implements UpdateProcessor {
         } catch (FeatureRequestor.InvalidSDKKeyException e) {
           logger.error("Received 401 error, no further polling requests will be made since SDK key is invalid");
           scheduler.shutdown();
+          initFuture.set(null); // if client is initializing, make it stop waiting; has no effect if already inited
         } catch (IOException e) {
           logger.error("Encountered exception in LaunchDarkly client when retrieving update", e);
         }

--- a/src/main/java/com/launchdarkly/client/PollingProcessor.java
+++ b/src/main/java/com/launchdarkly/client/PollingProcessor.java
@@ -2,12 +2,20 @@ package com.launchdarkly.client;
 
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.concurrent.*;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.launchdarkly.client.Util.httpErrorMessage;
+import static com.launchdarkly.client.Util.isHttpErrorRecoverable;
 
 class PollingProcessor implements UpdateProcessor {
   private static final Logger logger = LoggerFactory.getLogger(PollingProcessor.class);
@@ -55,10 +63,12 @@ class PollingProcessor implements UpdateProcessor {
             logger.info("Initialized LaunchDarkly client.");
             initFuture.set(null);
           }
-        } catch (FeatureRequestor.InvalidSDKKeyException e) {
-          logger.error("Received 401 error, no further polling requests will be made since SDK key is invalid");
-          scheduler.shutdown();
-          initFuture.set(null); // if client is initializing, make it stop waiting; has no effect if already inited
+        } catch (HttpErrorException e) {
+          logger.error(httpErrorMessage(e.getStatus(), "polling request", "will retry"));
+          if (!isHttpErrorRecoverable(e.getStatus())) {
+            scheduler.shutdown();
+            initFuture.set(null); // if client is initializing, make it stop waiting; has no effect if already inited
+          }
         } catch (IOException e) {
           logger.error("Encountered exception in LaunchDarkly client when retrieving update", e);
         }

--- a/src/main/java/com/launchdarkly/client/StreamProcessor.java
+++ b/src/main/java/com/launchdarkly/client/StreamProcessor.java
@@ -1,17 +1,5 @@
 package com.launchdarkly.client;
 
-import static com.launchdarkly.client.VersionedDataKind.FEATURES;
-import static com.launchdarkly.client.VersionedDataKind.SEGMENTS;
-
-import java.io.IOException;
-import java.net.URI;
-import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
@@ -21,9 +9,20 @@ import com.launchdarkly.eventsource.EventSource;
 import com.launchdarkly.eventsource.MessageEvent;
 import com.launchdarkly.eventsource.UnsuccessfulResponseException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.launchdarkly.client.VersionedDataKind.FEATURES;
+import static com.launchdarkly.client.VersionedDataKind.SEGMENTS;
+
 import okhttp3.Headers;
 
-class StreamProcessor implements UpdateProcessor {
+final class StreamProcessor implements UpdateProcessor {
   private static final String PUT = "put";
   private static final String PATCH = "patch";
   private static final String DELETE = "delete";
@@ -36,15 +35,21 @@ class StreamProcessor implements UpdateProcessor {
   private final LDConfig config;
   private final String sdkKey;
   private final FeatureRequestor requestor;
+  private final EventSourceCreator eventSourceCreator;
   private volatile EventSource es;
-  private AtomicBoolean initialized = new AtomicBoolean(false);
+  private final AtomicBoolean initialized = new AtomicBoolean(false);
 
-
-  StreamProcessor(String sdkKey, LDConfig config, FeatureRequestor requestor, FeatureStore featureStore) {
+  public static interface EventSourceCreator {
+    EventSource createEventSource(EventHandler handler, URI streamUri, ConnectionErrorHandler errorHandler, Headers headers);
+  }
+  
+  StreamProcessor(String sdkKey, LDConfig config, FeatureRequestor requestor, FeatureStore featureStore,
+      EventSourceCreator eventSourceCreator) {
     this.store = featureStore;
     this.config = config;
     this.sdkKey = sdkKey;
     this.requestor = requestor;
+    this.eventSourceCreator = eventSourceCreator != null ? eventSourceCreator : new DefaultEventSourceCreator();
   }
 
   @Override
@@ -162,36 +167,12 @@ class StreamProcessor implements UpdateProcessor {
       }
     };
 
-    es = createEventSource(handler,
+    es = eventSourceCreator.createEventSource(handler,
         URI.create(config.streamURI.toASCIIString() + "/all"),
         connectionErrorHandler,
         headers);
     es.start();
     return initFuture;
-  }
-  
-  @VisibleForTesting
-  protected EventSource createEventSource(EventHandler handler, URI streamUri, ConnectionErrorHandler errorHandler,
-                                          Headers headers) {
-    EventSource.Builder builder = new EventSource.Builder(handler, URI.create(config.streamURI.toASCIIString() + "/all"))
-        .connectionErrorHandler(errorHandler)
-        .headers(headers)
-        .reconnectTimeMs(config.reconnectTimeMs)
-        .connectTimeoutMs(config.connectTimeoutMillis)
-        .readTimeoutMs(DEAD_CONNECTION_INTERVAL_MS);
-    // Note that this is not the same read timeout that can be set in LDConfig.  We default to a smaller one
-    // there because we don't expect long delays within any *non*-streaming response that the LD client gets.
-    // A read timeout on the stream will result in the connection being cycled, so we set this to be slightly
-    // more than the expected interval between heartbeat signals.
-
-    if (config.proxy != null) {
-      builder.proxy(config.proxy);
-      if (config.proxyAuthenticator != null) {
-        builder.proxyAuthenticator(config.proxyAuthenticator);
-      }
-    }
-
-    return builder.build();
   }
   
   @Override
@@ -233,6 +214,30 @@ class StreamProcessor implements UpdateProcessor {
 
     public DeleteData() {
 
+    }
+  }
+  
+  private class DefaultEventSourceCreator implements EventSourceCreator {
+    public EventSource createEventSource(EventHandler handler, URI streamUri, ConnectionErrorHandler errorHandler, Headers headers) {
+      EventSource.Builder builder = new EventSource.Builder(handler, streamUri)
+          .connectionErrorHandler(errorHandler)
+          .headers(headers)
+          .reconnectTimeMs(config.reconnectTimeMs)
+          .connectTimeoutMs(config.connectTimeoutMillis)
+          .readTimeoutMs(DEAD_CONNECTION_INTERVAL_MS);
+      // Note that this is not the same read timeout that can be set in LDConfig.  We default to a smaller one
+      // there because we don't expect long delays within any *non*-streaming response that the LD client gets.
+      // A read timeout on the stream will result in the connection being cycled, so we set this to be slightly
+      // more than the expected interval between heartbeat signals.
+
+      if (config.proxy != null) {
+        builder.proxy(config.proxy);
+        if (config.proxyAuthenticator != null) {
+          builder.proxyAuthenticator(config.proxyAuthenticator);
+        }
+      }
+
+      return builder.build();
     }
   }
 }

--- a/src/main/java/com/launchdarkly/client/StreamProcessor.java
+++ b/src/main/java/com/launchdarkly/client/StreamProcessor.java
@@ -68,6 +68,7 @@ final class StreamProcessor implements UpdateProcessor {
         if ((t instanceof UnsuccessfulResponseException) &&
             ((UnsuccessfulResponseException) t).getCode() == 401) {
           logger.error("Received 401 error, no further streaming connection will be made since SDK key is invalid");
+          initFuture.set(null); // if client is initializing, make it stop waiting; has no effect if already inited
           return Action.SHUTDOWN;
         }
         return Action.PROCEED;

--- a/src/main/java/com/launchdarkly/client/Util.java
+++ b/src/main/java/com/launchdarkly/client/Util.java
@@ -32,4 +32,42 @@ class Util {
         .addHeader("Authorization", sdkKey)
         .addHeader("User-Agent", "JavaClient/" + LDClient.CLIENT_VERSION);
   }
+  
+  /**
+   * Tests whether an HTTP error status represents a condition that might resolve on its own if we retry.
+   * @param statusCode the HTTP status
+   * @return true if retrying makes sense; false if it should be considered a permanent failure
+   */
+  static boolean isHttpErrorRecoverable(int statusCode) {
+    if (statusCode >= 400 && statusCode < 500) {
+      switch (statusCode) {
+      case 408: // request timeout
+      case 429: // too many requests
+        return true;
+      default:
+        return false; // all other 4xx errors are unrecoverable
+      }
+    }
+    return true;
+  }
+  
+  /**
+   * Builds an appropriate log message for an HTTP error status.
+   * @param statusCode the HTTP status
+   * @param context description of what we were trying to do
+   * @param recoverableMessage description of our behavior if the error is recoverable; typically "will retry"
+   * @return a message string
+   */
+  static String httpErrorMessage(int statusCode, String context, String recoverableMessage) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("Received HTTP error ").append(statusCode);
+    switch (statusCode) {
+    case 401:
+    case 403:
+      sb.append(" (invalid SDK key)");
+    }
+    sb.append(" for ").append(context).append(" - ");
+    sb.append(isHttpErrorRecoverable(statusCode) ? recoverableMessage : "giving up permanently");
+    return sb.toString();
+  }
 }

--- a/src/test/java/com/launchdarkly/client/LDClientTest.java
+++ b/src/test/java/com/launchdarkly/client/LDClientTest.java
@@ -109,7 +109,7 @@ public class LDClientTest extends EasyMockSupport {
 
     expect(updateProcessor.start()).andReturn(initFuture);
     expect(initFuture.get(10L, TimeUnit.MILLISECONDS)).andReturn(null);
-    expect(updateProcessor.initialized()).andReturn(false);
+    expect(updateProcessor.initialized()).andReturn(false).anyTimes();
     replayAll();
 
     client = createMockClient(config);
@@ -125,7 +125,7 @@ public class LDClientTest extends EasyMockSupport {
 
     expect(updateProcessor.start()).andReturn(initFuture);
     expect(initFuture.get(10L, TimeUnit.MILLISECONDS)).andThrow(new TimeoutException());
-    expect(updateProcessor.initialized()).andReturn(false);
+    expect(updateProcessor.initialized()).andReturn(false).anyTimes();
     replayAll();
 
     client = createMockClient(config);
@@ -141,7 +141,7 @@ public class LDClientTest extends EasyMockSupport {
 
     expect(updateProcessor.start()).andReturn(initFuture);
     expect(initFuture.get(10L, TimeUnit.MILLISECONDS)).andThrow(new RuntimeException());
-    expect(updateProcessor.initialized()).andReturn(false);
+    expect(updateProcessor.initialized()).andReturn(false).anyTimes();
     replayAll();
 
     client = createMockClient(config);

--- a/src/test/java/com/launchdarkly/client/LDUserTest.java
+++ b/src/test/java/com/launchdarkly/client/LDUserTest.java
@@ -19,6 +19,7 @@ import static com.launchdarkly.client.TestUtil.jint;
 import static com.launchdarkly.client.TestUtil.js;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class LDUserTest {
 
@@ -239,6 +240,25 @@ public class LDUserTest {
         .name("Jane")
         .build();
     assertNull(user.getValueForEvaluation("height"));
+  }
+  
+  @Test
+  public void canAddCustomAttrWithJsonValue() {
+    JsonElement value = new JsonPrimitive("x");
+    LDUser user = new LDUser.Builder("key")
+        .custom("foo", value)
+        .build();
+    assertEquals(value, user.getCustom("foo"));
+  }
+  
+  @Test
+  public void canAddPrivateCustomAttrWithJsonValue() {
+    JsonElement value = new JsonPrimitive("x");
+    LDUser user = new LDUser.Builder("key")
+        .privateCustom("foo", value)
+        .build();
+    assertEquals(value, user.getCustom("foo"));
+    assertTrue(user.privateAttributeNames.contains("foo"));
   }
   
   @Test

--- a/src/test/java/com/launchdarkly/client/StreamProcessorTest.java
+++ b/src/test/java/com/launchdarkly/client/StreamProcessorTest.java
@@ -297,18 +297,7 @@ public class StreamProcessorTest extends EasyMockSupport {
   }
 
   private StreamProcessor createStreamProcessor(String sdkKey, LDConfig config) {
-    return new StreamProcessor(sdkKey, config, mockRequestor, featureStore) {
-      @Override
-      protected EventSource createEventSource(EventHandler handler, URI streamUri, ConnectionErrorHandler errorHandler,
-                                              Headers headers) {
-        
-        StreamProcessorTest.this.eventHandler = handler;
-        StreamProcessorTest.this.actualStreamUri = streamUri;
-        StreamProcessorTest.this.errorHandler = errorHandler;
-        StreamProcessorTest.this.headers = headers;
-        return mockEventSource;
-      }
-    };
+    return new StreamProcessor(sdkKey, config, mockRequestor, featureStore, new StubEventSourceCreator());
   }
   
   private String featureJson(String key, int version) {
@@ -335,5 +324,16 @@ public class StreamProcessorTest extends EasyMockSupport {
   
   private void assertSegmentInStore(Segment segment) {
     assertEquals(segment.getVersion(), featureStore.get(SEGMENTS, segment.getKey()).getVersion());
+  }
+  
+  private class StubEventSourceCreator implements StreamProcessor.EventSourceCreator {
+    public EventSource createEventSource(EventHandler handler, URI streamUri, ConnectionErrorHandler errorHandler,
+        Headers headers) {  
+      StreamProcessorTest.this.eventHandler = handler;
+      StreamProcessorTest.this.actualStreamUri = streamUri;
+      StreamProcessorTest.this.errorHandler = errorHandler;
+      StreamProcessorTest.this.headers = headers;
+      return mockEventSource;
+    }
   }
 }


### PR DESCRIPTION
## [4.2.0] - 2018-06-26
### Added:
- New overloads of `LDUser.Builder.custom` and `LDUser.Builder.privateCustom` allow you to set a custom attribute value to any JSON element.

### Changed:
- The client now treats most HTTP 4xx errors as unrecoverable: that is, after receiving such an error, it will not make any more HTTP requests for the lifetime of the client instance, in effect taking the client offline. This is because such errors indicate either a configuration problem (invalid SDK key) or a bug, which is not likely to resolve without a restart or an upgrade. This does not apply if the error is 400, 408, 429, or any 5xx error.
- During initialization, if the client receives any of the unrecoverable errors described above, the client constructor will return immediately; previously it would continue waiting until a timeout. The `initialized()` method will return false in this case.