### PR TITLE
prepare 4.2.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ LaunchDarkly SDK for Java
 [![Javadocs](http://javadoc.io/badge/com.launchdarkly/launchdarkly-client.svg)](http://javadoc.io/doc/com.launchdarkly/launchdarkly-client)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Flaunchdarkly%2Fjava-client.svg?type=shield)](https://app.fossa.io/projects/git%2Bhttps%3A%2F%2Fgithub.com%2Flaunchdarkly%2Fjava-client?ref=badge_shield)
 
+Supported Java versions
+-----------------------
+
+This version of the LaunchDarkly SDK works with Java 7 and above.
+
 Quick setup
 -----------
 

--- a/src/main/java/com/launchdarkly/client/RedisFeatureStore.java
+++ b/src/main/java/com/launchdarkly/client/RedisFeatureStore.java
@@ -259,6 +259,7 @@ public class RedisFeatureStore implements FeatureStore {
         if (cache != null) {
           cache.invalidate(new CacheKey(kind, newItem.getKey()));
         }
+        return;
       } finally {
         if (jedis != null) {
           jedis.unwatch();

--- a/src/main/java/com/launchdarkly/client/Util.java
+++ b/src/main/java/com/launchdarkly/client/Util.java
@@ -41,6 +41,7 @@ class Util {
   static boolean isHttpErrorRecoverable(int statusCode) {
     if (statusCode >= 400 && statusCode < 500) {
       switch (statusCode) {
+      case 400: // bad request
       case 408: // request timeout
       case 429: // too many requests
         return true;

--- a/src/test/java/com/launchdarkly/client/DefaultEventProcessorTest.java
+++ b/src/test/java/com/launchdarkly/client/DefaultEventProcessorTest.java
@@ -392,6 +392,11 @@ public class DefaultEventProcessorTest {
   }
 
   @Test
+  public void http400ErrorIsRecoverable() throws Exception {
+    testRecoverableHttpError(400);
+  }
+
+  @Test
   public void http401ErrorIsUnrecoverable() throws Exception {
     testUnrecoverableHttpError(401);
   }

--- a/src/test/java/com/launchdarkly/client/PollingProcessorTest.java
+++ b/src/test/java/com/launchdarkly/client/PollingProcessorTest.java
@@ -53,6 +53,11 @@ public class PollingProcessorTest extends EasyMockSupport {
     pollingProcessor.close();
     verifyAll();
   }
+
+  @Test
+  public void http400ErrorIsRecoverable() throws Exception {
+    testRecoverableHttpError(400);
+  }
   
   @Test
   public void http401ErrorIsUnrecoverable() throws Exception {

--- a/src/test/java/com/launchdarkly/client/StreamProcessorTest.java
+++ b/src/test/java/com/launchdarkly/client/StreamProcessorTest.java
@@ -282,6 +282,11 @@ public class StreamProcessorTest extends EasyMockSupport {
     ConnectionErrorHandler.Action action = errorHandler.onConnectionError(new IOException());
     assertEquals(ConnectionErrorHandler.Action.PROCEED, action);
   }
+
+  @Test
+  public void http400ErrorIsRecoverable() throws Exception {
+    testRecoverableHttpError(400);
+  }
   
   @Test
   public void http401ErrorIsUnrecoverable() throws Exception {


### PR DESCRIPTION
## [4.2.1] - 2018-07-16
### Fixed:
- Should not permanently give up on posting events if the server returns a 400 error.
- Fixed a bug in the Redis store that caused an unnecessary extra Redis query (and a debug-level log message about updating a flag with the same version) after every update of a flag.