### PR TITLE
Support conversion from an LDUser to a JsonObject

### DIFF
--- a/src/main/java/com/launchdarkly/client/LDUser.java
+++ b/src/main/java/com/launchdarkly/client/LDUser.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.TypeAdapter;
 import com.google.gson.internal.Streams;
@@ -141,6 +142,11 @@ public class LDUser {
       return custom.get(key);
     }
     return null;
+  }
+
+  JsonObject toJsonObject(LDConfig config) {
+      JsonElement tree = config.gson.toJsonTree(this);
+      return tree.getAsJsonObject();
   }
 
   @Override

--- a/src/main/java/com/launchdarkly/client/LDUser.java
+++ b/src/main/java/com/launchdarkly/client/LDUser.java
@@ -2,6 +2,7 @@ package com.launchdarkly.client;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -15,6 +16,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -144,9 +147,30 @@ public class LDUser {
     return null;
   }
 
-  JsonObject toJsonObject(LDConfig config) {
-      JsonElement tree = config.gson.toJsonTree(this);
-      return tree.getAsJsonObject();
+  JsonObject toJsConfig(LDConfig config) {
+    JsonElement tree = new Gson().toJsonTree(this);
+
+    Set<String> privateAttributeSet = new HashSet<>();
+    privateAttributeSet.addAll(this.privateAttributeNames);
+    privateAttributeSet.addAll(config.privateAttrNames);
+
+    List<String> attrs = new ArrayList<>();
+    attrs.addAll(privateAttributeSet);
+    Collections.sort(attrs);
+
+    JsonArray array = new JsonArray();
+    for (String element : attrs) {
+      array.add(new JsonPrimitive(element));
+    }
+
+    JsonObject object = tree.getAsJsonObject();
+    object.add("privateAttributeNames", array);
+
+    if (config.allAttributesPrivate) {
+      object.addProperty("allAttributesPrivate", true);
+    }
+
+    return object;
   }
 
   @Override

--- a/src/test/java/com/launchdarkly/client/LDUserTest.java
+++ b/src/test/java/com/launchdarkly/client/LDUserTest.java
@@ -93,6 +93,16 @@ public class LDUserTest {
   }
 
   @Test
+  public void testLDJsonObject() {
+      LDConfig config = LDConfig.DEFAULT;
+      LDUser user = new LDUser.Builder("key")
+              .build();
+      JsonObject object = user.toJsonObject(config);
+
+      assertEquals("key", object.get("key").getAsString());
+  }
+
+  @Test
   public void testLDUserJsonSerializationContainsCountryAsTwoDigitCode() {
     LDConfig config = LDConfig.DEFAULT;
     Gson gson = config.gson;

--- a/src/test/java/com/launchdarkly/client/LDUserTest.java
+++ b/src/test/java/com/launchdarkly/client/LDUserTest.java
@@ -93,13 +93,53 @@ public class LDUserTest {
   }
 
   @Test
-  public void testLDJsonObject() {
-      LDConfig config = LDConfig.DEFAULT;
-      LDUser user = new LDUser.Builder("key")
-              .build();
-      JsonObject object = user.toJsonObject(config);
+  public void testLDUserJsConfig() {
+    LDConfig config = LDConfig.DEFAULT;
+    LDUser user = new LDUser.Builder("key")
+            .privateCustom("private-key", "private-value")
+            .custom("public-key", "public-value")
+            .build();
 
-      assertEquals("key", object.get("key").getAsString());
+    JsonObject object = user.toJsConfig(config);
+
+    assertEquals("key", object.get("key").getAsString());
+
+    JsonArray privateAttributeNames = object.get("privateAttributeNames").getAsJsonArray();
+    assertEquals(1, privateAttributeNames.size());
+    assertEquals("private-key", privateAttributeNames.get(0).getAsString());
+
+    assertEquals("private-value", object.get("custom").getAsJsonObject().get("private-key").getAsString());
+    assertEquals("public-value", object.get("custom").getAsJsonObject().get("public-key").getAsString());
+  }
+
+  @Test
+  public void testLDUserJsConfigAllAttributesPrivate() {
+    LDConfig config = new LDConfig.Builder()
+            .allAttributesPrivate(true)
+            .build();
+    LDUser user = new LDUser.Builder("key")
+            .build();
+
+    JsonObject object = user.toJsConfig(config);
+
+    assertTrue(object.get("allAttributesPrivate").getAsBoolean());
+  }
+
+  @Test
+  public void testLDUserJsConfigPrivate() {
+    LDConfig config = new LDConfig.Builder()
+            .privateAttributeNames("private-key")
+            .build();
+    LDUser user = new LDUser.Builder("key")
+            .privateCustom("private-key2", "private-value2")
+            .build();
+
+    JsonObject object = user.toJsConfig(config);
+
+    JsonArray privateAttributeNames = object.get("privateAttributeNames").getAsJsonArray();
+    assertEquals(2, privateAttributeNames.size());
+    assertEquals("private-key", privateAttributeNames.get(0).getAsString());
+    assertEquals("private-key2", privateAttributeNames.get(1).getAsString());
   }
 
   @Test


### PR DESCRIPTION
We want to extract the LDUser state from server, so it can be used to initialize client-side properties.  Since we are already sending a secureModeHash to the client, it is natural to collect user context on the server side as well.

I couldn't find any way to get access to LDUser.UserAdapter, or any other solution.